### PR TITLE
RMB-30 move raml util

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "raml-util"]
-	path = raml-util
+	path = ramls/raml-util
 	url = https://github.com/folio-org/raml.git

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,6 @@
     <aspectj.version>1.8.9</aspectj.version>
     <module_name>acquisitions</module_name>
     <ramlfiles_path>${basedir}/ramls</ramlfiles_path>
-    <ramlfiles_util_path>${basedir}/raml-util</ramlfiles_util_path>
     <http.port>8081</http.port>
     <log_path>${basedir}/logs/acquisitions.log</log_path>
     <gclog_path>${basedir}/logs/gclogs/*.log</gclog_path>
@@ -212,22 +211,6 @@
               <resources>
                 <resource>
                   <directory>${ramlfiles_path}</directory>
-                  <filtering>true</filtering>
-                </resource>
-              </resources>
-            </configuration>
-          </execution>
-          <execution>
-            <id>copy-resources-2</id>
-            <phase>prepare-package</phase>
-            <goals>
-              <goal>copy-resources</goal>
-            </goals>
-            <configuration>
-              <outputDirectory>${basedir}/target/classes/apidocs/raml-util</outputDirectory>
-              <resources>
-                <resource>
-                  <directory>${ramlfiles_util_path}</directory>
                   <filtering>true</filtering>
                 </resource>
               </resources>

--- a/ramls/_schemas/README.md
+++ b/ramls/_schemas/README.md
@@ -1,1 +1,1 @@
-As a workaround to FOLIO-573, when any schema file refers to an additional schema file, then use the filename of that referenced second schema as the "key" name in the RAML "schemas" section, and wherever that schema is utilised in RAML and schema files.
+When any schema file refers to an additional schema file, then also use that pathname of the referenced second schema as the "key" name in the RAML "schemas" section, and wherever that schema is utilised in RAML files. Also ensure that all such referenced files are below the parent file.

--- a/ramls/acquisitions/acquisitions.raml
+++ b/ramls/acquisitions/acquisitions.raml
@@ -21,16 +21,16 @@ schemas:
   - vendors: !include ../_schemas/vendors.schema
 
 traits:
-  - secured: !include ../../raml-util/traits/auth.raml
-  - orderable: !include ../../raml-util/traits/orderable.raml
-  - pageable:  !include ../../raml-util/traits/pageable.raml
-  - searchable: !include ../../raml-util/traits/searchable.raml
-  - language: !include ../../raml-util/traits/language.raml
+  - secured: !include ../raml-util/traits/auth.raml
+  - orderable: !include ../raml-util/traits/orderable.raml
+  - pageable:  !include ../raml-util/traits/pageable.raml
+  - searchable: !include ../raml-util/traits/searchable.raml
+  - language: !include ../raml-util/traits/language.raml
 
 resourceTypes:
-  - collection: !include ../../raml-util/rtypes/collection.raml
-  - collection-item: !include ../../raml-util/rtypes/item-collection.raml
-  - get-only: !include ../../raml-util/rtypes/get-only.raml
+  - collection: !include ../raml-util/rtypes/collection.raml
+  - collection-item: !include ../raml-util/rtypes/item-collection.raml
+  - get-only: !include ../raml-util/rtypes/get-only.raml
 
 /funds:
   displayName: Funds


### PR DESCRIPTION
Move raml-util to inside the ramls directory.
Enables reliable use of pathname for $ref in schema files.